### PR TITLE
[discuss] Checkstyle: always use spaces

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,6 +64,29 @@
           </execution>
         </executions>
       </plugin>
+        <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-checkstyle-plugin</artifactId>
+            <version>2.15</version>
+            <configuration>
+                <includes>**\/*.java,**\/*.xml</includes>
+                <sourceDirectory>src/main/archetype</sourceDirectory>
+                <configLocation>src/main/resources/checkstyle.xml</configLocation>
+                <encoding>UTF-8</encoding>
+                <consoleOutput>true</consoleOutput>
+                <failsOnError>true</failsOnError>
+                <linkXRef>false</linkXRef>
+            </configuration>
+            <executions>
+                <execution>
+                    <id>checkstyle</id>
+                    <phase>verify</phase>
+                    <goals>
+                        <goal>check</goal>
+                    </goals>
+                </execution>
+            </executions>
+        </plugin>
     </plugins>
 
     <pluginManagement>

--- a/src/main/resources/checkstyle.xml
+++ b/src/main/resources/checkstyle.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<!DOCTYPE module PUBLIC "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
+	"http://www.puppycrawl.com/dtds/configuration_1_3.dtd">
+<module name="Checker">
+	<module name="FileTabCharacter">
+	    <property name="eachLine" value="true"/>
+	</module>
+</module>


### PR DESCRIPTION
Let's make sure we always use spaces instead of tabs. This just creates the config, we should clean up first and then merge this one.