### PR TITLE
Set the content type for non-HTML 404s.

### DIFF
--- a/src/main/archetype/ui.apps/src/main/content/jcr_root/apps/sling/servlet/errorhandler/ResponseStatus.java
+++ b/src/main/archetype/ui.apps/src/main/content/jcr_root/apps/sling/servlet/errorhandler/ResponseStatus.java
@@ -21,6 +21,7 @@ public class ResponseStatus extends WCMUse {
     
     @Override
     public void activate() throws Exception {
-        getResponse().setStatus(404);
+    	getResponse().setStatus(404);
+    	getResponse().setContentType("text/html");
     }
 }

--- a/src/main/archetype/ui.apps/src/main/content/jcr_root/apps/sling/servlet/errorhandler/ResponseStatus.java
+++ b/src/main/archetype/ui.apps/src/main/content/jcr_root/apps/sling/servlet/errorhandler/ResponseStatus.java
@@ -21,7 +21,7 @@ public class ResponseStatus extends WCMUse {
     
     @Override
     public void activate() throws Exception {
-    	getResponse().setStatus(404);
-    	getResponse().setContentType("text/html");
+        getResponse().setStatus(404);
+        getResponse().setContentType("text/html");
     }
 }


### PR DESCRIPTION
If you visit non-HTML 404 pages, the mime type is not correctly set and thus, displays the HTML as plain text. For example...

/content/test.jpg
/content/something.json
/content/something-else

All returns 404.html as plain-text.

This pull request sets the content-type to be HTML to display when a file cannot be found. It's probably worth a discussion whether there should be excluded mime-types for this... for example, maybe json should return { response : 'not found' }.