### PR TITLE
#69 updated resulting pom to Java 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: false
 language: java
 install: true
-jdk: openjdk8
+jdk: oraclejdk8
 script: mvn verify
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: false
 language: java
 install: true
-jdk: openjdk7
+jdk: openjdk8
 script: mvn verify
 cache:
   directories:

--- a/src/main/archetype/pom.xml
+++ b/src/main/archetype/pom.xml
@@ -87,8 +87,8 @@
                                     <version>[2.2.1,)</version>
                                 </requireMavenVersion>
                                 <requireJavaVersion>
-                                    <message>Project must be compiled with Java 6 or higher</message>
-                                    <version>1.6.0</version>
+                                    <message>Project must be compiled with Java 8 or higher</message>
+                                    <version>1.8.0</version>
                                 </requireJavaVersion>
                             </rules>
                         </configuration>
@@ -100,8 +100,8 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
+                    <source>1.8</source>
+                    <target>1.8</target>
                 </configuration>
             </plugin>
             <!-- Maven IntelliJ IDEA Plugin -->
@@ -110,7 +110,7 @@
                 <artifactId>maven-idea-plugin</artifactId>
                 <version>2.2.1</version>
                 <configuration>
-                    <jdkLevel>1.6</jdkLevel>
+                    <jdkLevel>1.8</jdkLevel>
                     <linkModules>true</linkModules>
                     <downloadSources>true</downloadSources>
                 </configuration>


### PR DESCRIPTION
Raised to resolve #69 

Updated the Maven Compiler Plugin config to use Java 1.8 as source and target. Adjusted the configurations of the Maven Enforcer Plugin and the Maven Idea Plugin accordingly.

I ran into some trouble compiling the archetype project. It would refuse to run the `install` goal during the integration tests (happens on the `master` branch too, not sure why). Clearing the contents of the `archetype.properties` file allowed me to build it and generate a project manually. The generated project seemed to have the right values in the pom and builds cleanly on a `mvn clean install`.

Let's see if Travis builds it alright. Could be an environment problem on my side.