### PR TITLE
Issue #77: Set version of maven-invoker to 2.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -98,7 +98,14 @@
       <plugins>
         <plugin>
           <artifactId>maven-archetype-plugin</artifactId>
-          <version>2.2</version>
+          <version>2.4</version>
+          <dependencies>
+            <dependency>
+              <groupId>org.apache.maven.shared</groupId>
+              <artifactId>maven-invoker</artifactId>
+              <version>2.2</version>
+            </dependency>
+          </dependencies>
         </plugin>
       </plugins>
     </pluginManagement>
@@ -117,7 +124,7 @@
       <uniqueVersion>false</uniqueVersion>
     </snapshotRepository>
   </distributionManagement>
-  
+
   <properties>
       <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>


### PR DESCRIPTION
See #77 for a description of the problem I'm trying to solve here.]

Following a suggestion in
https://issues.apache.org/jira/browse/ARCHETYPE-488, I upgraded
maven-invoker.

This allowed the build to run the automated tests and pass successfully.