### PR TITLE
Fix  for issue 78 in aem-eclipse-developer-tools project

### DIFF
--- a/src/main/archetype/core/pom.xml
+++ b/src/main/archetype/core/pom.xml
@@ -37,15 +37,6 @@
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
                 <extensions>true</extensions>
-                <executions>
-                    <execution>
-                        <id>bundle-manifest</id>
-                        <phase>process-classes</phase>
-                        <goals>
-                            <goal>manifest</goal>
-                        </goals>
-                    </execution>
-                </executions>
                 <configuration>
                     <instructions>
                         <!-- Import any version of javax.inject, to allow running on multiple versions of AEM -->


### PR DESCRIPTION
Removed executions tag and its subtags.According to this [issue](https://github.com/tesla/m2eclipse-tycho/issues/4), this extra execution step interferes with m2eclipse plugin configurator. the plugin does not ignore this step which generates illegalArgumentException during the create/import of the AEM project in/to Eclipse.