### PR TITLE
Update project archetype to release 2.0.4 of the Core Components

### DIFF
--- a/src/main/archetype/pom.xml
+++ b/src/main/archetype/pom.xml
@@ -488,7 +488,7 @@
                 <groupId>com.adobe.cq</groupId>
                 <artifactId>core.wcm.components.all</artifactId>
                 <type>zip</type>
-                <version>1.0.6</version>
+                <version>2.0.2</version>
             </dependency>
             <!-- Apache Sling Dependencies -->
             <dependency>

--- a/src/main/archetype/pom.xml
+++ b/src/main/archetype/pom.xml
@@ -488,7 +488,7 @@
                 <groupId>com.adobe.cq</groupId>
                 <artifactId>core.wcm.components.all</artifactId>
                 <type>zip</type>
-                <version>2.0.2</version>
+                <version>2.0.4</version>
             </dependency>
             <!-- Apache Sling Dependencies -->
             <dependency>

--- a/src/main/archetype/ui.apps/src/main/content/jcr_root/apps/__appsFolderName__/clientlibs/clientlib-base/.content.xml
+++ b/src/main/archetype/ui.apps/src/main/content/jcr_root/apps/__appsFolderName__/clientlibs/clientlib-base/.content.xml
@@ -3,4 +3,4 @@
     jcr:primaryType="cq:ClientLibraryFolder"
     allowProxy="{Boolean}true"
     categories="[${cssId}.base]"
-    embed="[core.wcm.components.image.v1,core.wcm.components.breadcrumb.v1,core.wcm.components.form.container.v1,core.wcm.components.form.text.v1,core.wcm.components.list.v1,${cssId}.breadcrumb]"/>
+    embed="[core.wcm.components.image.v2,core.wcm.components.breadcrumb.v2,core.wcm.components.search.v1,core.wcm.components.form.text.v2,${cssId}.breadcrumb]"/>

--- a/src/main/archetype/ui.apps/src/main/content/jcr_root/apps/__appsFolderName__/components/content/breadcrumb/.content.xml
+++ b/src/main/archetype/ui.apps/src/main/content/jcr_root/apps/__appsFolderName__/components/content/breadcrumb/.content.xml
@@ -2,5 +2,5 @@
 <jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
     jcr:primaryType="cq:Component"
     jcr:title="Breadcrumb"
-    sling:resourceSuperType="core/wcm/components/breadcrumb/v1/breadcrumb"
+    sling:resourceSuperType="core/wcm/components/breadcrumb/v2/breadcrumb"
     componentGroup="${componentGroupName}"/>

--- a/src/main/archetype/ui.apps/src/main/content/jcr_root/apps/__appsFolderName__/components/content/breadcrumb/clientlib/less/breadcrumb.less
+++ b/src/main/archetype/ui.apps/src/main/content/jcr_root/apps/__appsFolderName__/components/content/breadcrumb/clientlib/less/breadcrumb.less
@@ -13,18 +13,11 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-.breadcrumb {
-    display: inline-block;
-    list-style: none;
-    padding: 0;
+.cmp-breadcrumb__item {
+    &:before {
+        content: "\003e";
 
-    & .breadcrumb-item {
-        float: left;
-
-        & + .breadcrumb-item::before {
-            display: inline-block; //
-            padding: 0 10px;
-            content: "\003e";
-        }
+        display: inline-block;
+        padding: 0 10px;
     }
 }

--- a/src/main/archetype/ui.apps/src/main/content/jcr_root/apps/__appsFolderName__/components/content/image/.content.xml
+++ b/src/main/archetype/ui.apps/src/main/content/jcr_root/apps/__appsFolderName__/components/content/image/.content.xml
@@ -2,5 +2,5 @@
 <jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
     jcr:primaryType="cq:Component"
     jcr:title="Image"
-    sling:resourceSuperType="core/wcm/components/image/v1/image"
+    sling:resourceSuperType="core/wcm/components/image/v2/image"
     componentGroup="${componentGroupName}"/>

--- a/src/main/archetype/ui.apps/src/main/content/jcr_root/apps/__appsFolderName__/components/content/languagenavigation/.content.xml
+++ b/src/main/archetype/ui.apps/src/main/content/jcr_root/apps/__appsFolderName__/components/content/languagenavigation/.content.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
     jcr:primaryType="cq:Component"
-    jcr:title="Form Text"
-    sling:resourceSuperType="core/wcm/components/form/text/v2/text"
-    componentGroup="${componentGroupName} Form"/>
+    jcr:title="Language Navigation"
+    sling:resourceSuperType="core/wcm/components/languagenavigation/v1/languagenavigation"
+    componentGroup="${componentGroupName}"/>

--- a/src/main/archetype/ui.apps/src/main/content/jcr_root/apps/__appsFolderName__/components/content/list/.content.xml
+++ b/src/main/archetype/ui.apps/src/main/content/jcr_root/apps/__appsFolderName__/components/content/list/.content.xml
@@ -2,5 +2,5 @@
 <jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
     jcr:primaryType="cq:Component"
     jcr:title="List"
-    sling:resourceSuperType="core/wcm/components/list/v1/list"
+    sling:resourceSuperType="core/wcm/components/list/v2/list"
     componentGroup="${componentGroupName}"/>

--- a/src/main/archetype/ui.apps/src/main/content/jcr_root/apps/__appsFolderName__/components/content/navigation/.content.xml
+++ b/src/main/archetype/ui.apps/src/main/content/jcr_root/apps/__appsFolderName__/components/content/navigation/.content.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
     jcr:primaryType="cq:Component"
-    jcr:title="Form Text"
-    sling:resourceSuperType="core/wcm/components/form/text/v2/text"
-    componentGroup="${componentGroupName} Form"/>
+    jcr:title="Navigation"
+    sling:resourceSuperType="core/wcm/components/navigation/v1/navigation"
+    componentGroup="${componentGroupName}"/>

--- a/src/main/archetype/ui.apps/src/main/content/jcr_root/apps/__appsFolderName__/components/content/search/.content.xml
+++ b/src/main/archetype/ui.apps/src/main/content/jcr_root/apps/__appsFolderName__/components/content/search/.content.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
     jcr:primaryType="cq:Component"
-    jcr:title="Form Text"
-    sling:resourceSuperType="core/wcm/components/form/text/v2/text"
-    componentGroup="${componentGroupName} Form"/>
+    jcr:title="Quick Search"
+    sling:resourceSuperType="core/wcm/components/search/v1/search"
+    componentGroup="${componentGroupName}"/>

--- a/src/main/archetype/ui.apps/src/main/content/jcr_root/apps/__appsFolderName__/components/content/text/.content.xml
+++ b/src/main/archetype/ui.apps/src/main/content/jcr_root/apps/__appsFolderName__/components/content/text/.content.xml
@@ -2,5 +2,5 @@
 <jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
     jcr:primaryType="cq:Component"
     jcr:title="Text"
-    sling:resourceSuperType="core/wcm/components/text/v1/text"
+    sling:resourceSuperType="core/wcm/components/text/v2/text"
     componentGroup="${componentGroupName}"/>

--- a/src/main/archetype/ui.apps/src/main/content/jcr_root/apps/__appsFolderName__/components/content/title/.content.xml
+++ b/src/main/archetype/ui.apps/src/main/content/jcr_root/apps/__appsFolderName__/components/content/title/.content.xml
@@ -2,5 +2,5 @@
 <jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
     jcr:primaryType="cq:Component"
     jcr:title="Title"
-    sling:resourceSuperType="core/wcm/components/title/v1/title"
+    sling:resourceSuperType="core/wcm/components/title/v2/title"
     componentGroup="${componentGroupName}"/>

--- a/src/main/archetype/ui.apps/src/main/content/jcr_root/apps/__appsFolderName__/components/form/button/.content.xml
+++ b/src/main/archetype/ui.apps/src/main/content/jcr_root/apps/__appsFolderName__/components/form/button/.content.xml
@@ -2,5 +2,5 @@
 <jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
     jcr:primaryType="cq:Component"
     jcr:title="Form Button"
-    sling:resourceSuperType="core/wcm/components/form/button/v1/button"
+    sling:resourceSuperType="core/wcm/components/form/button/v2/button"
     componentGroup="${componentGroupName} Form"/>

--- a/src/main/archetype/ui.apps/src/main/content/jcr_root/apps/__appsFolderName__/components/form/container/.content.xml
+++ b/src/main/archetype/ui.apps/src/main/content/jcr_root/apps/__appsFolderName__/components/form/container/.content.xml
@@ -3,6 +3,6 @@
     jcr:primaryType="cq:Component"
     jcr:title="Form Container"
     jcr:description="Container for components that allow users to submit information"
-    sling:resourceSuperType="core/wcm/components/form/container/v1/container"
+    sling:resourceSuperType="core/wcm/components/form/container/v2/container"
     componentGroup="${componentGroupName} Form"
     cq:isContainer="{Boolean}true"/>

--- a/src/main/archetype/ui.apps/src/main/content/jcr_root/apps/__appsFolderName__/components/form/container/new/.content.xml
+++ b/src/main/archetype/ui.apps/src/main/content/jcr_root/apps/__appsFolderName__/components/form/container/new/.content.xml
@@ -2,5 +2,5 @@
 <jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
   jcr:primaryType="cq:Component"
   jcr:title="New Paragraph - Form Container"
-  sling:resourceSuperType="core/wcm/components/form/container/v1/container/new"
+  sling:resourceSuperType="core/wcm/components/form/container/v2/container/new"
   componentGroup=".hidden"/>

--- a/src/main/archetype/ui.apps/src/main/content/jcr_root/apps/__appsFolderName__/components/form/hidden/.content.xml
+++ b/src/main/archetype/ui.apps/src/main/content/jcr_root/apps/__appsFolderName__/components/form/hidden/.content.xml
@@ -2,5 +2,5 @@
 <jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
     jcr:primaryType="cq:Component"
     jcr:title="Form Hidden"
-    sling:resourceSuperType="core/wcm/components/form/hidden/v1/hidden"
+    sling:resourceSuperType="core/wcm/components/form/hidden/v2/hidden"
     componentGroup="${componentGroupName} Form"/>

--- a/src/main/archetype/ui.apps/src/main/content/jcr_root/apps/__appsFolderName__/components/form/options/.content.xml
+++ b/src/main/archetype/ui.apps/src/main/content/jcr_root/apps/__appsFolderName__/components/form/options/.content.xml
@@ -2,5 +2,5 @@
 <jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
     jcr:primaryType="cq:Component"
     jcr:title="Form Options"
-    sling:resourceSuperType="core/wcm/components/form/options/v1/options"
+    sling:resourceSuperType="core/wcm/components/form/options/v2/options"
     componentGroup="${componentGroupName} Form"/>

--- a/src/main/archetype/ui.apps/src/main/content/jcr_root/apps/__appsFolderName__/components/structure/page/.content.xml
+++ b/src/main/archetype/ui.apps/src/main/content/jcr_root/apps/__appsFolderName__/components/structure/page/.content.xml
@@ -2,5 +2,5 @@
 <jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
     jcr:primaryType="cq:Component"
     jcr:title="${siteName} Page"
-    sling:resourceSuperType="core/wcm/components/page/v1/page"
+    sling:resourceSuperType="core/wcm/components/page/v2/page"
     componentGroup=".hidden"/>

--- a/src/main/archetype/ui.content/src/main/content/jcr_root/conf/__confFolderName__/settings/wcm/templates/content-page/structure/.content.xml
+++ b/src/main/archetype/ui.content/src/main/content/jcr_root/conf/__confFolderName__/settings/wcm/templates/content-page/structure/.content.xml
@@ -9,6 +9,15 @@
         <root
             jcr:primaryType="nt:unstructured"
             sling:resourceType="wcm/foundation/components/responsivegrid">
+            <languagenavigation
+                jcr:primaryType="nt:unstructured"
+                sling:resourceType="${appsFolderName}/components/content/languagenavigation"/>
+            <search
+                jcr:primaryType="nt:unstructured"
+                sling:resourceType="${appsFolderName}/components/content/search"/>
+            <navigation
+                jcr:primaryType="nt:unstructured"
+                sling:resourceType="${appsFolderName}/components/content/navigation"/>
             <breadcrumb
                 jcr:primaryType="nt:unstructured"
                 sling:resourceType="${appsFolderName}/components/content/breadcrumb"/>

--- a/src/main/archetype/ui.content/src/main/content/jcr_root/conf/__confFolderName__/settings/wcm/templates/content-page/structure/.content.xml
+++ b/src/main/archetype/ui.content/src/main/content/jcr_root/conf/__confFolderName__/settings/wcm/templates/content-page/structure/.content.xml
@@ -11,13 +11,17 @@
             sling:resourceType="wcm/foundation/components/responsivegrid">
             <languagenavigation
                 jcr:primaryType="nt:unstructured"
-                sling:resourceType="${appsFolderName}/components/content/languagenavigation"/>
+                sling:resourceType="${appsFolderName}/components/content/languagenavigation"
+                navigationRoot="/content/${contentFolderName}/"
+                structureDepth="1"/>
             <search
                 jcr:primaryType="nt:unstructured"
-                sling:resourceType="${appsFolderName}/components/content/search"/>
+                sling:resourceType="${appsFolderName}/components/content/search"
+                searchRoot="/content/${contentFolderName}/"/>
             <navigation
                 jcr:primaryType="nt:unstructured"
-                sling:resourceType="${appsFolderName}/components/content/navigation"/>
+                sling:resourceType="${appsFolderName}/components/content/navigation"
+                navigationRoot="/content/${contentFolderName}/"/>
             <breadcrumb
                 jcr:primaryType="nt:unstructured"
                 sling:resourceType="${appsFolderName}/components/content/breadcrumb"/>


### PR DESCRIPTION
- Updates core.wcm.components.all dependency to release 2.0.4
- Adds new proxy components for navigation, language navigation and search components
- Updates existing proxy component versions
- Updates clientlib versions
- Adds the navigation, language navigation and search components to the content page template structure
- Fixes bespoke breadcrumb styles for V2 breadcrumb component