### PR TITLE
it.tests do not run with AEM 6.4

### DIFF
--- a/src/main/archetype/it.launcher/pom.xml
+++ b/src/main/archetype/it.launcher/pom.xml
@@ -255,7 +255,7 @@
         <dependency>
             <groupId>org.apache.sling</groupId>
             <artifactId>org.apache.sling.junit.scriptable</artifactId>
-            <version>1.0.8</version>
+            <version>1.0.12</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/src/main/archetype/it.launcher/pom.xml
+++ b/src/main/archetype/it.launcher/pom.xml
@@ -234,8 +234,6 @@
                                 <sling.additional.bundle.4>${rootArtifactId}.core</sling.additional.bundle.4>
                                 <sling.additional.bundle.5>org.apache.sling.junit.remote</sling.additional.bundle.5>
                                 <sling.additional.bundle.6>org.apache.sling.testing.tools</sling.additional.bundle.6>
-                                <sling.additional.bundle.7>httpclient-osgi</sling.additional.bundle.7>
-                                <sling.additional.bundle.8>httpcore-osgi</sling.additional.bundle.8>
                             </systemPropertyVariables>
                         </configuration>
                     </plugin>
@@ -274,20 +272,6 @@
             <groupId>org.apache.sling</groupId>
             <artifactId>org.apache.sling.servlets.post</artifactId>
             <version>2.3.4</version>
-            <scope>provided</scope>
-        </dependency>
-        
-        <!-- sling testing tools bundles requires httpclient -->
-        <dependency>
-            <groupId>org.apache.httpcomponents</groupId>
-            <artifactId>httpclient-osgi</artifactId>
-            <version>4.5.2</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.httpcomponents</groupId>
-            <artifactId>httpcore-osgi</artifactId>
-            <version>4.4.5</version>
             <scope>provided</scope>
         </dependency>
         


### PR DESCRIPTION
the it.tests generated from the archetype do not run with AEM 6.4 due to mismatch in package dependencies. This PR includes a fix and an optimization to not deploy HTTP clients which is no longer required because recent AEM versions include up-to-date ones.