### PR TITLE
Using artifactId as default value for /apps and /conf folder can lead…

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,11 +62,10 @@ Either use the [AEM Eclipse extension](https://docs.adobe.com/docs/en/dev-tools/
 
 Or use your mvn skills:
 
-    mvn org.apache.maven.plugins:maven-archetype-plugin:2.4:generate \
+    mvn archetype:generate \
      -DarchetypeGroupId=com.adobe.granite.archetypes \
      -DarchetypeArtifactId=aem-project-archetype \
-     -DarchetypeVersion=15 \
-     -DarchetypeCatalog=https://repo.adobe.com/nexus/content/groups/public/
+     -DarchetypeVersion=15
 
 Where 15 is the archetype version number that you want to use (see archetype versions below).
 
@@ -93,6 +92,7 @@ The latest version of the archetype has the following requirements
 
 * Adobe Experience Manager 6.3 SP2 or higher
 * Apache Maven (3.3.9 or newer)
+* Adobe Public Maven Repository in maven settings, see [Knowledge Base](https://helpx.adobe.com/experience-manager/kb/SetUpTheAdobeMavenRepository.html) article for details.
 
 See below for support for older versions of AEM.
 

--- a/src/main/resources/META-INF/maven/archetype-metadata.xml
+++ b/src/main/resources/META-INF/maven/archetype-metadata.xml
@@ -20,39 +20,57 @@
 
     <requiredProperties>
         <!--
+            This is the folder under /apps into which the bundle and package content will be installed.
+        -->
+        <requiredProperty key="appsFolderName">
+            <validationRegex>^[a-zA-Z0-9\-_]+$</validationRegex>
+        </requiredProperty>
+        <!--
+            Maven artifact groupId for all projects
+        -->
+        <requiredProperty key="groupId">
+            <validationRegex>^[a-zA-Z0-9\.\-_]+$</validationRegex>
+        </requiredProperty>
+        <!--
+            Maven artifact "root" artifactId, is suffixed for the individual modules
+        -->
+        <requiredProperty key="artifactId">
+            <defaultValue>${groupId}.${appsFolderName}</defaultValue>
+            <validationRegex>^[a-zA-Z0-9\.\-_]+$</validationRegex>
+        </requiredProperty>
+        <!--
            This is the name which will be set as the artifact name and used to derive the bundle
            and package names.
         -->
         <requiredProperty key="artifactName">
-            <defaultValue>${artifactId}</defaultValue>
+            <defaultValue>${appsFolderName}</defaultValue>
         </requiredProperty>
             <!--
                This is the group identifier for the package. Used with the
                Package Manager and Package Share.
             -->
         <requiredProperty key="packageGroup">
-        	<defaultValue>${artifactId}</defaultValue>
+        	<defaultValue>${appsFolderName}</defaultValue>
+            <validationRegex>^[a-zA-Z0-9\-_]+$</validationRegex>
         </requiredProperty>
-        <!--
-           This is the folder under /apps into which the bundle and package content will be installed.
-        -->
-        <requiredProperty key="appsFolderName">
-            <defaultValue>${artifactId}</defaultValue>
-        </requiredProperty>        
         <requiredProperty key="contentFolderName">
-            <defaultValue>${artifactId}</defaultValue>
+            <defaultValue>${appsFolderName}</defaultValue>
+            <validationRegex>^[a-zA-Z0-9\-_]+$</validationRegex>
         </requiredProperty>
         <requiredProperty key="confFolderName">
-            <defaultValue>${artifactId}</defaultValue>
+            <defaultValue>${appsFolderName}</defaultValue>
+            <validationRegex>^[a-zA-Z0-9\-_]+$</validationRegex>
         </requiredProperty>
         <requiredProperty key="cssId">
-            <defaultValue>${artifactId}</defaultValue>
+            <defaultValue>${appsFolderName}</defaultValue>
+            <validationRegex>^[a-zA-Z0-9\-_]+$</validationRegex>
         </requiredProperty>
         <requiredProperty key="componentGroupName">
-            <defaultValue>${artifactId}</defaultValue>
+            <defaultValue>${appsFolderName}</defaultValue>
+            <validationRegex>^[a-zA-Z0-9\.\-_]+$</validationRegex>
         </requiredProperty>
         <requiredProperty key="siteName">
-            <defaultValue>${artifactId}</defaultValue>
+            <defaultValue>${appsFolderName}</defaultValue>
         </requiredProperty>
     </requiredProperties>
 


### PR DESCRIPTION
… to broken features (fixes #133)

- changed input order of archetype properties
- added input validation for jcr path variables
- default value of artifactId is based on groupId and apps folder name