### PR TITLE
Update dependencies & build

### DIFF
--- a/src/main/archetype/core/pom.xml
+++ b/src/main/archetype/core/pom.xml
@@ -37,15 +37,39 @@
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
                 <extensions>true</extensions>
+                <executions>
+                    <execution>
+                        <id>generate-osgi-metadata-for-unittests</id>
+                        <goals>
+                            <goal>manifest</goal>
+                        </goals>
+                        <phase>process-classes</phase>
+                    </execution>
+                </executions>
                 <configuration>
+                    <exportScr>true</exportScr>
                     <instructions>
-                        <!-- Import any version of javax.inject, to allow running on multiple versions of AEM -->
+                        <!-- Import any version of javax.inject, to allow 
+                            running on multiple versions of AEM -->
                         <Import-Package>javax.inject;version=0.0.0,*</Import-Package>
                         <Sling-Model-Packages>
                             ${package}.core
                         </Sling-Model-Packages>
+                        <_dsannotations>*</_dsannotations>
+                        <_metatypeannotations>*</_metatypeannotations>
+                        <!-- Allow the processing of SCR annotations via 
+                            a bnd plugin -->
+                        <_plugin>org.apache.felix.scrplugin.bnd.SCRDescriptorBndPlugin;destdir=${project.build.outputDirectory}</_plugin>
                     </instructions>
                 </configuration>
+                <dependencies>
+                    <!-- Add a dependency to the bnd plugin -->
+                    <dependency>
+                        <groupId>org.apache.felix</groupId>
+                        <artifactId>org.apache.felix.scr.bnd</artifactId>
+                        <version>1.9.0</version>
+                    </dependency>
+                </dependencies>
             </plugin>
         </plugins>
     </build>
@@ -64,6 +88,10 @@
             <groupId>org.osgi</groupId>
             <artifactId>osgi.annotation</artifactId>
         </dependency>
+        <dependency>
+            <groupId>javax.inject</groupId>
+            <artifactId>javax.inject</artifactId>
+        </dependency>
         <!-- Other Dependencies -->
         <dependency>
             <groupId>org.slf4j</groupId>
@@ -75,7 +103,7 @@
         </dependency>
         <dependency>
             <groupId>javax.servlet</groupId>
-            <artifactId>servlet-api</artifactId>
+            <artifactId>javax.servlet-api</artifactId>
         </dependency>
         <dependency>
             <groupId>com.adobe.aem</groupId>
@@ -100,7 +128,7 @@
         </dependency>
         <dependency>
             <groupId>org.apache.sling</groupId>
-            <artifactId>org.apache.sling.testing.sling-mock</artifactId>
+            <artifactId>org.apache.sling.testing.sling-mock.junit4</artifactId>
         </dependency>
         <dependency>
             <groupId>uk.org.lidalia</groupId>

--- a/src/main/archetype/pom.xml
+++ b/src/main/archetype/pom.xml
@@ -14,7 +14,9 @@
  |  See the License for the specific language governing permissions and
  |  limitations under the License.
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>${groupId}</groupId>
     <artifactId>${artifactId}</artifactId>
@@ -87,7 +89,8 @@
                                     <version>[3.3.9,)</version>
                                 </requireMavenVersion>
                                 <requireJavaVersion>
-                                    <message>Project must be compiled with Java 8 or higher</message>
+                                    <message>Project must be compiled
+                                        with Java 8 or higher</message>
                                     <version>1.8.0</version>
                                 </requireJavaVersion>
                             </rules>
@@ -220,7 +223,7 @@
                 <plugin>
                     <groupId>org.apache.felix</groupId>
                     <artifactId>maven-bundle-plugin</artifactId>
-                    <version>3.3.0</version>
+                    <version>4.1.0</version>
                     <inherited>true</inherited>
                 </plugin>
                 <!-- Maven Enforcer Plugin -->
@@ -241,7 +244,8 @@
                     <artifactId>build-helper-maven-plugin</artifactId>
                     <version>3.0.0</version>
                 </plugin>
-                <!--This plugin's configuration is used to store Eclipse m2e settings only. It has no influence on the Maven build itself.-->
+                <!--This plugin's configuration is used to store Eclipse 
+                    m2e settings only. It has no influence on the Maven build itself. -->
                 <plugin>
                     <groupId>org.eclipse.m2e</groupId>
                     <artifactId>lifecycle-mapping</artifactId>
@@ -279,7 +283,7 @@
                                         </goals>
                                     </pluginExecutionFilter>
                                     <action>
-                                         <ignore />
+                                        <ignore />
                                     </action>
                                 </pluginExecution>
                                 <pluginExecution>
@@ -313,7 +317,7 @@
 
     <profiles>
         <!-- ====================================================== -->
-        <!-- A D O B E   P U B L I C   P R O F I L E                -->
+        <!-- A D O B E P U B L I C P R O F I L E -->
         <!-- ====================================================== -->
         <profile>
             <id>adobe-public</id>
@@ -362,14 +366,14 @@
         <!-- Development profile: install only the bundle -->
         <profile>
             <id>autoInstallBundle</id>
-            <!--
-                To enable this feature for a bundle, the maven-sling-plugin
+            <!-- 
+                To enable this feature for a bundle, the maven-sling-plugin 
                 (without configuration) needs to be included:
-
-                <plugin>
-                    <groupId>org.apache.sling</groupId>
-                    <artifactId>maven-sling-plugin</artifactId>
-                </plugin>
+                 
+                <plugin> 
+                    <groupId>org.apache.sling</groupId> 
+                    <artifactId>maven-sling-plugin</artifactId> 
+                 </plugin> 
             -->
             <activation>
                 <activeByDefault>false</activeByDefault>
@@ -478,7 +482,7 @@
 
 
     <!-- ====================================================================== -->
-    <!-- D E P E N D E N C I E S                                                -->
+    <!-- D E P E N D E N C I E S -->
     <!-- ====================================================================== -->
     <dependencyManagement>
         <dependencies>
@@ -500,6 +504,11 @@
                 <artifactId>osgi.annotation</artifactId>
                 <version>6.0.1</version>
                 <scope>provided</scope>
+            </dependency>
+            <dependency>
+                <groupId>javax.inject</groupId>
+                <artifactId>javax.inject</artifactId>
+                <version>1</version>
             </dependency>
             <!-- Logging Dependencies -->
             <dependency>
@@ -526,14 +535,14 @@
             <dependency>
                 <groupId>org.apache.sling</groupId>
                 <artifactId>org.apache.sling.models.api</artifactId>
-                <version>1.0.0</version>
+                <version>1.3.6</version>
                 <scope>provided</scope>
             </dependency>
             <!-- Servlet API -->
             <dependency>
                 <groupId>javax.servlet</groupId>
-                <artifactId>servlet-api</artifactId>
-                <version>2.5</version>
+                <artifactId>javax.servlet-api</artifactId>
+                <version>3.1.0</version>
                 <scope>provided</scope>
             </dependency>
             <dependency>
@@ -567,13 +576,13 @@
             <dependency>
                 <groupId>org.slf4j</groupId>
                 <artifactId>slf4j-simple</artifactId>
-                <version>1.7.21</version>
+                <version>1.7.25</version>
                 <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>org.mockito</groupId>
                 <artifactId>mockito-core</artifactId>
-                <version>2.7.22</version>
+                <version>2.23.4</version>
                 <scope>test</scope>
             </dependency>
             <dependency>
@@ -584,8 +593,8 @@
             </dependency>
             <dependency>
                 <groupId>org.apache.sling</groupId>
-                <artifactId>org.apache.sling.testing.sling-mock</artifactId>
-                <version>2.2.18</version>
+                <artifactId>org.apache.sling.testing.sling-mock.junit4</artifactId>
+                <version>2.3.4</version>
                 <scope>test</scope>
             </dependency>
             <dependency>

--- a/src/main/archetype/ui.apps/pom.xml
+++ b/src/main/archetype/ui.apps/pom.xml
@@ -152,7 +152,7 @@
 
         <dependency>
             <groupId>javax.servlet</groupId>
-            <artifactId>servlet-api</artifactId>
+            <artifactId>javax.servlet-api</artifactId>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
Update to the pom:
* update maven-bundle-plugin to 4.1.0 (generate metadata for OSGI r6 annotations)
* run the maven-bundle-plugin twice to generate metadata also for unittests (so you can use the sling-mocks properly)
* updated sling-mock dependencies
* updated some other dependencies to keep up with AEM 6.3 (sling models, servlet API, ...)